### PR TITLE
강의 수정 기능 구현

### DIFF
--- a/src/InputModal/InputModal.jsx
+++ b/src/InputModal/InputModal.jsx
@@ -1,0 +1,241 @@
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  FormControlLabel,
+  FormLabel,
+  MenuItem,
+  Radio,
+  RadioGroup,
+  TextField,
+} from '@mui/material';
+import { Stack } from '@mui/system';
+import React, { useCallback } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+import { useRecoilState } from 'recoil';
+import { timeTableState } from '../store/store';
+import { v4 as uuidv1 } from 'uuid';
+import { useEffect } from 'react';
+
+const timeOptions = new Array(12).fill(null).map((e, i) => ({
+  value: i + 9,
+  label: i + 9,
+}));
+
+const checkOverLap = (A, B) =>
+  B.start < A.start ? B.end > A.start : B.start < A.end;
+
+function InputModal({ showModal, handleClose }) {
+  const {
+    formState: { errors },
+    control,
+    getValues,
+    handleSubmit,
+    reset,
+  } = useForm();
+  const [timeTableData, setttimeTableData] = useRecoilState(timeTableState);
+  useEffect(() => {
+    if (showModal) {
+      reset({
+        lecturename: '',
+        day: 'fri',
+        startTime: 9,
+        endTime: 10,
+        lectureColor: '#FFFFFF',
+      });
+    }
+  }, [reset, showModal]);
+  const Submit = useCallback(
+    ({ lectureName, day, startTime, endTime, lectureColor }) => {
+      let valid = true;
+      for (let index = 0; index < timeTableData[day].length; index++) {
+        if (
+          checkOverLap(timeTableData[day][index], {
+            start: startTime,
+            end: endTime,
+          })
+        ) {
+          valid = false;
+          break;
+        }
+      }
+
+      if (!valid) {
+        alert('해당 시간대에 이미 강의가 있어. 다시 확인해봐 ');
+        return;
+      }
+
+      const data = {
+        start: startTime,
+        end: endTime,
+        name: lectureName,
+        color: lectureColor,
+        id: uuidv1(),
+      };
+
+      setttimeTableData((oldTimeData) => ({
+        ...oldTimeData,
+        [day]: [...oldTimeData[day], data],
+      }));
+
+      handleClose();
+    },
+    [handleClose, setttimeTableData, timeTableData],
+  );
+  return (
+    <Dialog open={showModal} onClose={handleClose}>
+      <form onSubmit={handleSubmit(Submit)}>
+        <DialogTitle align="center"> 강의 정보 입력</DialogTitle>
+        <DialogContent style={{ width: '400px' }}>
+          <Controller
+            control={control}
+            name="lectureName"
+            rules={{ required: true }}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                error={!!errors.lectureName}
+                style={{ marginTop: '30px', width: '350px' }}
+                autoComplete="off"
+                label="강의명"
+              />
+            )}
+          />
+          {errors.lectureName?.type === 'required' && (
+            <p style={{ color: '#d32f2f' }}>무슨 강의인데?</p>
+          )}
+          <FormControl style={{ marginTop: '30px' }}>
+            <FormLabel>요일</FormLabel>
+            <Controller
+              control={control}
+              name="day"
+              rules={{ required: true }}
+              render={({ field }) => (
+                <RadioGroup {...field} style={{ display: 'block' }}>
+                  <FormControlLabel
+                    value="mon"
+                    control={<Radio />}
+                    label="월"
+                  />
+                  <FormControlLabel
+                    value="tue"
+                    control={<Radio />}
+                    label="화"
+                  />
+                  <FormControlLabel
+                    value="wed"
+                    control={<Radio />}
+                    label="수"
+                  />
+                  <FormControlLabel
+                    value="thu"
+                    control={<Radio />}
+                    label="목"
+                  />
+                  <FormControlLabel
+                    value="fri"
+                    control={<Radio />}
+                    label="금"
+                  />
+                </RadioGroup>
+              )}
+            />
+            {errors.day?.type === 'required' && (
+              <p style={{ color: '#d32f2f' }}> 무슨 요일에 시작하는데?</p>
+            )}
+          </FormControl>
+          <Stack spacing={3} style={{ marginTop: '30px', width: '350px' }}>
+            <Controller
+              control={control}
+              name="startTime"
+              rules={{
+                required: true,
+                validate: (value) => getValues('endTime') > value,
+              }}
+              render={({ field }) => (
+                <TextField
+                  {...field}
+                  select
+                  error={
+                    !!errors.startTime ||
+                    !!(errors.endTime?.type === 'validate')
+                  }
+                  style={{ marginTop: '30px', width: '350px' }}
+                  label="시작 시간"
+                  placeholder="몇시 수업?"
+                >
+                  {timeOptions.map((option) => (
+                    <MenuItem key={option.value} value={option.value}>
+                      {option.label}
+                    </MenuItem>
+                  ))}
+                </TextField>
+              )}
+            />
+            {errors.startTime?.type === 'required' && (
+              <p style={{ color: '#d32f2f' }}> 몇시에 시작하는데?</p>
+            )}
+            {errors.startTime?.type === 'validate' && (
+              <p style={{ color: '#d32f2f' }}> 시간설정 이상한데?</p>
+            )}
+
+            <Controller
+              control={control}
+              name="endTime"
+              rules={{
+                required: true,
+                validate: (value) => getValues('startTime') < value,
+              }}
+              render={({ field }) => (
+                <TextField
+                  {...field}
+                  select
+                  error={!!errors.endTime}
+                  style={{ marginTop: '30px', width: '350px' }}
+                  label="종료 시간"
+                  placeholder="몇시에 끝나?"
+                >
+                  {timeOptions.map((option) => (
+                    <MenuItem key={option.value} value={option.value}>
+                      {option.label}
+                    </MenuItem>
+                  ))}
+                </TextField>
+              )}
+            />
+            {errors.endTime?.type === 'required' && (
+              <p style={{ color: '#d32f2f' }}> 몇시에 끝나는데?</p>
+            )}
+            {errors.endTime?.type === 'validate' && (
+              <p style={{ color: '#d32f2f' }}> 시간설정 이상한데?</p>
+            )}
+          </Stack>
+          <div style={{ marginTop: '30px' }}>
+            <label htmlFor="lectureColor">시간표 색상:</label>
+            <Controller
+              control={control}
+              name="lectureColor"
+              render={({ field }) => (
+                <input
+                  {...field}
+                  style={{ marginLeft: '30px' }}
+                  id="lectureColor"
+                  type="color"
+                />
+              )}
+            />
+          </div>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleClose}>취소</Button>
+          <Button type="submit">입력</Button>
+        </DialogActions>
+      </form>
+    </Dialog>
+  );
+}
+
+export default InputModal;

--- a/src/InputModal/InputModal.jsx
+++ b/src/InputModal/InputModal.jsx
@@ -28,7 +28,16 @@ const timeOptions = new Array(12).fill(null).map((e, i) => ({
 const checkOverLap = (A, B) =>
   B.start < A.start ? B.end > A.start : B.start < A.end;
 
-function InputModal({ showModal, handleClose }) {
+function InputModal({
+  showModal,
+  handleClose,
+  dayData = 'mon',
+  startTimeData = 9,
+  endTimeData = 10,
+  lectureNameData = '',
+  colorData = '#FFFFFF',
+  idNum,
+}) {
   const {
     formState: { errors },
     control,
@@ -40,14 +49,22 @@ function InputModal({ showModal, handleClose }) {
   useEffect(() => {
     if (showModal) {
       reset({
-        lecturename: '',
-        day: 'fri',
-        startTime: 9,
-        endTime: 10,
-        lectureColor: '#FFFFFF',
+        lecturename: lectureNameData,
+        day: dayData,
+        startTime: startTimeData,
+        endTime: endTimeData,
+        lectureColor: colorData,
       });
     }
-  }, [reset, showModal]);
+  }, [
+    colorData,
+    dayData,
+    endTimeData,
+    lectureNameData,
+    reset,
+    showModal,
+    startTimeData,
+  ]);
   const Submit = useCallback(
     ({ lectureName, day, startTime, endTime, lectureColor }) => {
       let valid = true;
@@ -85,9 +102,59 @@ function InputModal({ showModal, handleClose }) {
     },
     [handleClose, setttimeTableData, timeTableData],
   );
+
+  const Edit = useCallback(
+    ({ lectureName, day, startTime, endTime, lectureColor }) => {
+      let valid = true;
+
+      for (let index = 0; index < timeTableData[day].length; index++) {
+        if (
+          checkOverLap(timeTableData[day][index], {
+            start: startTime,
+            end: endTime,
+          }) &&
+          timeTableData[day][index]['id'] !== idNum
+        ) {
+          valid = false;
+          break;
+        }
+      }
+
+      if (!valid) {
+        alert('해당 시간대에 이미 강의가 있어. 다시 확인해봐 ');
+        return;
+      }
+      const filteredDayData = [
+        ...timeTableData[dayData].filter((data) => data.id !== idNum),
+      ];
+
+      const newTimeTableData = {
+        ...timeTableData,
+        [dayData]: filteredDayData,
+      };
+      const newDayData = [
+        ...newTimeTableData[day],
+        {
+          start: startTime,
+          end: endTime,
+          id: idNum,
+          name: lectureName,
+          color: lectureColor,
+        },
+      ];
+
+      setttimeTableData({
+        ...newTimeTableData,
+        [day]: newDayData,
+      });
+
+      handleClose();
+    },
+    [dayData, handleClose, idNum, setttimeTableData, timeTableData],
+  );
   return (
     <Dialog open={showModal} onClose={handleClose}>
-      <form onSubmit={handleSubmit(Submit)}>
+      <form onSubmit={handleSubmit(idNum ? Edit : Submit)}>
         <DialogTitle align="center"> 강의 정보 입력</DialogTitle>
         <DialogContent style={{ width: '400px' }}>
           <Controller

--- a/src/Timetable/TimeTable.jsx
+++ b/src/Timetable/TimeTable.jsx
@@ -1,4 +1,5 @@
 import {
+  Button,
   Table,
   TableBody,
   TableCell,
@@ -7,10 +8,12 @@ import {
   TableRow,
   Typography,
 } from '@mui/material';
-import React from 'react';
+import React, { useCallback } from 'react';
 import TimeTableRow from './TimeTableRow';
 import { withStyles } from '@mui/styles';
-
+import { AddBox } from '@mui/icons-material';
+import { useState } from 'react';
+import InputModal from '../InputModal/InputModal';
 const hourData = Array.from({ length: 11 }, (i, j) => j + 9);
 const styles = () => ({
   Table: {
@@ -21,6 +24,10 @@ const styles = () => ({
 });
 
 const TimeTable = ({ classes }) => {
+  const [showModal, setshowModal] = useState(false);
+  const handleClose = useCallback(() => {
+    setshowModal(false);
+  }, []);
   return (
     <>
       <TableContainer
@@ -35,26 +42,34 @@ const TimeTable = ({ classes }) => {
         <Typography variant="h2" fontWeight={10} component="div" align="center">
           강의시간표
         </Typography>
+        <Button
+          variant="contain"
+          sx={{ float: 'right' }}
+          endIcon={<AddBox />}
+          onClick={() => setshowModal(true)}
+        >
+          강의 추가
+        </Button>
         <Table className={classes.Table}>
           <TableHead>
             <TableRow>
               <TableCell align="center" width={100}>
-                Time
+                시간
               </TableCell>
               <TableCell align="center" width={200}>
-                Mon
+                월
               </TableCell>
               <TableCell align="center" width={200}>
-                Tue
+                화
               </TableCell>
               <TableCell align="center" width={200}>
-                Wed
+                수
               </TableCell>
               <TableCell align="center" width={200}>
-                Thu
+                목
               </TableCell>
               <TableCell align="center" width={200}>
-                Fri
+                금
               </TableCell>
             </TableRow>
           </TableHead>
@@ -70,6 +85,7 @@ const TimeTable = ({ classes }) => {
           </TableBody>
         </Table>
       </TableContainer>
+      <InputModal showModal={showModal} handleClose={handleClose} />
     </>
   );
 };

--- a/src/Timetable/TimeTable.jsx
+++ b/src/Timetable/TimeTable.jsx
@@ -14,6 +14,8 @@ import { withStyles } from '@mui/styles';
 import { AddBox } from '@mui/icons-material';
 import { useState } from 'react';
 import InputModal from '../InputModal/InputModal';
+import { timeTableState } from '../store/store';
+import { useRecoilValue } from 'recoil';
 const hourData = Array.from({ length: 11 }, (i, j) => j + 9);
 const styles = () => ({
   Table: {
@@ -24,10 +26,31 @@ const styles = () => ({
 });
 
 const TimeTable = ({ classes }) => {
+  const timeTableData = useRecoilValue(timeTableState);
   const [showModal, setshowModal] = useState(false);
+  const [editInfo, seteditInfo] = useState({});
   const handleClose = useCallback(() => {
     setshowModal(false);
+    seteditInfo({});
   }, []);
+
+  const Edit = useCallback(
+    (day, id) => {
+      const { start, end, name, color } = timeTableData[day].find(
+        (lectureInfo) => lectureInfo.id === id,
+      );
+      seteditInfo({
+        dayData: day,
+        startTimeData: start,
+        endTimeData: end,
+        lectureNameData: name,
+        colorData: color,
+        idNum: id,
+      });
+      setshowModal(true);
+    },
+    [timeTableData],
+  );
   return (
     <>
       <TableContainer
@@ -79,13 +102,17 @@ const TimeTable = ({ classes }) => {
                 <TableCell align="center">{`${time}:00-${
                   time + 1
                 }:00`}</TableCell>
-                <TimeTableRow timeNum={time} />
+                <TimeTableRow timeNum={time} Edit={Edit} />
               </TableRow>
             ))}
           </TableBody>
         </Table>
       </TableContainer>
-      <InputModal showModal={showModal} handleClose={handleClose} />
+      <InputModal
+        showModal={showModal}
+        handleClose={handleClose}
+        {...editInfo}
+      />
     </>
   );
 };

--- a/src/Timetable/TimeTableCell.jsx
+++ b/src/Timetable/TimeTableCell.jsx
@@ -1,10 +1,13 @@
+import DeleteIcon from '@mui/icons-material/Delete';
+import EditIcon from '@mui/icons-material/Edit';
 import { TableCell } from '@mui/material';
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { useRecoilState } from 'recoil';
 import { timeTableState } from '../store/store';
 
-function TimeTableCell({ day, timeNum }) {
+function TimeTableCell({ day, timeNum, Edit }) {
   const [timeTableData, settimeTableData] = useRecoilState(timeTableState);
+  const [hover, sethover] = useState(false);
 
   const timeData = useMemo(
     () =>
@@ -13,6 +16,11 @@ function TimeTableCell({ day, timeNum }) {
       ),
     [day, timeNum, timeTableData],
   );
+
+  const handleEdit = useCallback(
+    () => Edit(day, timeData.id),
+    [Edit, day, timeData?.id],
+  );
   return (
     <>
       {timeData?.start === timeNum ? (
@@ -20,8 +28,16 @@ function TimeTableCell({ day, timeNum }) {
           style={{ backgroundColor: timeData.color, position: 'relative' }}
           align="center"
           rowSpan={timeData.end - timeData.start}
+          onMouseOver={() => sethover(true)}
+          onMouseLeave={() => sethover(false)}
         >
           {timeData.name}
+          {hover ? (
+            <div style={{ position: 'absolute', top: 5, right: 5 }}>
+              <EditIcon style={{ cursor: 'pointer' }} onClick={handleEdit} />
+              <DeleteIcon style={{ cursor: 'pointer' }} onClick={handleEdit} />
+            </div>
+          ) : null}
         </TableCell>
       ) : timeData?.start < timeNum && timeNum < timeData?.end ? null : (
         <TableCell />

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -3,10 +3,10 @@ import { atom } from 'recoil';
 export const timeTableState = atom({
   key: 'timeTableState',
   default: {
-    mon: [{ start: 9, end: 11, name: '교양', color: 'red', id: 1 }],
-    tue: [{ start: 9, end: 12, name: '수학', color: 'orange', id: 2 }],
-    wed: [{ start: 9, end: 13, name: '영어', color: 'yellow', id: 3 }],
-    thu: [{ start: 9, end: 14, name: '물리', color: 'green', id: 4 }],
-    fri: [{ start: 9, end: 15, name: '지구과학', color: 'blue', id: 5 }],
+    mon: [],
+    tue: [],
+    wed: [],
+    thu: [],
+    fri: [],
   },
 });


### PR DESCRIPTION

* 강의 시간표에 등록된 강의에 마우스 커서를 올리면 우측 상단에 `EditIcon`과 `DeleteIcon`이 나타나게 하고, `EdiotIcon`을 클릭하면 수정 화면이 나타나게 설정함

*`TimeTable`에서 해당 강의가 가지고 있는 데이터와 함께, `Modal`창이 나타나는 기준 데이터인 `showModal`의 값을 true로 변경해주는 `setshowModal(true)`를  보내주는 `Edit`을 생성

* `Edit`을 `TimeTableCell`의 prop으로 보내주고 Edit을 호출해주는 `handleEdit`을 `EditIcon`의 `onClick`으로 추가해서 모달 창이 나타나게 설정함

* 수정한 뒤에 입력을 하는 과정에서 만약 다른 강의가 있는 곳으로 이동을 시키면 중복 되어버리기 때문에 중복을 확인하는 과정을 거치고,  이전에 해당 id로 생성한 강의 내용을 제거한 다음에 새로 생성하여 렌더링 하는 방식으로 수정하는 `Edit`메소드를 `InputModal`에 작성함

* 이때 사용자가 submit을 하는 순간 id 값의 존재 유무에 따라 `Submit`과 `Ecit`이 호출된다.

* store의 테스트 데이터를 제거한 이유는 color의 값을 string으로 해놓으면 수정을 시도할때 현재 강의 데이터중에서 색깔을 읽어오지 못하는 현상을 발견했기 때문이며, 제대로 추가 및 수정이 되는지의 여부를 확인하기 위해서 그냥 전부 제거하기로 함
