### PR TITLE
강의 삭제 기능 추가

### DIFF
--- a/src/ConfirmModal/ConfirmModal.jsx
+++ b/src/ConfirmModal/ConfirmModal.jsx
@@ -1,0 +1,41 @@
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+} from '@mui/material';
+import React, { useCallback } from 'react';
+import { useState } from 'react';
+import DoubleConfirm from './DoubleConfirm';
+
+function ConfirmModal({
+  open,
+  handleClose,
+  handleDelete,
+  doubleopen,
+  confirmDelete,
+}) {
+  return (
+    <>
+      <Dialog open={open} onClose={handleClose}>
+        <DialogTitle align="center"> 강의 삭제</DialogTitle>
+        <DialogContent style={{ width: '400px' }}>
+          <DialogContentText>이 강의 삭제할거야?</DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleClose}>아니</Button>
+          <Button onClick={handleDelete}>그래</Button>
+        </DialogActions>
+        <DoubleConfirm
+          doubleopen={doubleopen}
+          handleClose={handleClose}
+          confirmDelete={confirmDelete}
+        />
+      </Dialog>
+    </>
+  );
+}
+
+export default ConfirmModal;

--- a/src/ConfirmModal/DoubleConfirm.jsx
+++ b/src/ConfirmModal/DoubleConfirm.jsx
@@ -1,0 +1,26 @@
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+} from '@mui/material';
+import React from 'react';
+
+function DoubleConfirm({ doubleopen, handleClose, confirmDelete }) {
+  return (
+    <Dialog open={doubleopen} onClose={handleClose}>
+      <DialogTitle align="center"> 진짜 삭제하는거지?</DialogTitle>
+      <DialogContent style={{ width: '300px' }}>
+        <DialogContentText>지우면 다시 복구 못한다?</DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={confirmDelete}>알았다니까</Button>
+        <Button onClick={handleClose}>잠깐만</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+export default DoubleConfirm;

--- a/src/Timetable/TimeTableCell.jsx
+++ b/src/Timetable/TimeTableCell.jsx
@@ -3,11 +3,14 @@ import EditIcon from '@mui/icons-material/Edit';
 import { TableCell } from '@mui/material';
 import React, { useCallback, useMemo, useState } from 'react';
 import { useRecoilState } from 'recoil';
+import ConfirmModal from '../ConfirmModal/ConfirmModal';
 import { timeTableState } from '../store/store';
 
 function TimeTableCell({ day, timeNum, Edit }) {
   const [timeTableData, settimeTableData] = useRecoilState(timeTableState);
   const [hover, sethover] = useState(false);
+  const [open, setopen] = useState(false);
+  const [doubleopen, setdoubleopen] = useState(false);
 
   const timeData = useMemo(
     () =>
@@ -16,6 +19,28 @@ function TimeTableCell({ day, timeNum, Edit }) {
       ),
     [day, timeNum, timeTableData],
   );
+  const handleClose = useCallback(() => {
+    setopen(false);
+    setdoubleopen(false);
+  }, []);
+  const handleConfirm = useCallback(() => setopen(true), []);
+  const handleDelete = useCallback(() => {
+    setdoubleopen(true);
+  }, []);
+
+  const confirmDelete = useCallback(() => {
+    settimeTableData((oldtimeTableData) => {
+      const newDayData = oldtimeTableData[day].filter(
+        (data) => data.id !== timeData.id,
+      );
+      return {
+        ...oldtimeTableData,
+        [day]: newDayData,
+      };
+    });
+    setopen(false);
+    setdoubleopen(false);
+  }, [day, settimeTableData, timeData?.id]);
 
   const handleEdit = useCallback(
     () => Edit(day, timeData.id),
@@ -35,13 +60,23 @@ function TimeTableCell({ day, timeNum, Edit }) {
           {hover ? (
             <div style={{ position: 'absolute', top: 5, right: 5 }}>
               <EditIcon style={{ cursor: 'pointer' }} onClick={handleEdit} />
-              <DeleteIcon style={{ cursor: 'pointer' }} onClick={handleEdit} />
+              <DeleteIcon
+                style={{ cursor: 'pointer' }}
+                onClick={handleConfirm}
+              />
             </div>
           ) : null}
         </TableCell>
       ) : timeData?.start < timeNum && timeNum < timeData?.end ? null : (
         <TableCell />
       )}
+      <ConfirmModal
+        open={open}
+        handleClose={handleClose}
+        handleDelete={handleDelete}
+        confirmDelete={confirmDelete}
+        doubleopen={doubleopen}
+      ></ConfirmModal>
     </>
   );
 }


### PR DESCRIPTION
* `DeleteIcon`을 클릭하면 삭제 여부를 확인하는 `ConfirmModal`을 나타나게 하는 `handleConfirm`을 작성함

* `ConfirmModal`에서 나타난 `Button`중에서 `그래`를 선택한 경우 `DoubleConfirm`이 나타나서 최종적으로 삭제 여부를 확인하고 난 다음에 `알았다니까`버튼을 누르면 `confirmDelete`가 호출된다.

*`confirmDelete`는 선택한 강의 `id`를 `filter`를 사용해서 제거한뒤 나머지 데이터를 `newDayData`로 정의하고 해당 데이터로 변경한다.